### PR TITLE
Renaming Hic to HiC to fix Issue#1

### DIFF
--- a/docs/Book.tex
+++ b/docs/Book.tex
@@ -553,8 +553,8 @@ Imagine you have RNA-seq of a collection of labeled normal lung and lung cancer 
 \hypertarget{hmm-bioinformatics-applications}{%
 \section{HMM Bioinformatics Applications}\label{hmm-bioinformatics-applications}}
 
-\hypertarget{Hic}{%
-\chapter{HiC}\label{Hic}}
+\hypertarget{HiC}{%
+\chapter{HiC}\label{HiC}}
 
 \hypertarget{introduction-to-chromatin-interaction-and-organization}{%
 \section{Introduction to Chromatin Interaction and Organization}\label{introduction-to-chromatin-interaction-and-organization}}


### PR DESCRIPTION
The HTML version of the book breaks the index page due to HiC being referenced as HiC,
Tex to HTML conversion still needs to be done.
Suggested Edit for #1 